### PR TITLE
Added Declaration of showLinks in wot.h

### DIFF
--- a/wotc/wot.h
+++ b/wotc/wot.h
@@ -15,7 +15,7 @@ namespace libwot {
 
     void showGraphviz(WebOfTrust *wot);
 
-    void showLinks(int32_t member, int32_t distance, int32_t distanceMax, int32_t maxCertStock, int32_t **wot)
+    void showLinks(int32_t member, int32_t distance, int32_t distanceMax, int32_t maxCertStock, int32_t **wot);
 
     void showDurationMS(high_resolution_clock::time_point t1);
 

--- a/wotc/wot.h
+++ b/wotc/wot.h
@@ -15,6 +15,8 @@ namespace libwot {
 
     void showGraphviz(WebOfTrust *wot);
 
+    void showLinks(int32_t member, int32_t distance, int32_t distanceMax, int32_t maxCertStock, int32_t **wot)
+
     void showDurationMS(high_resolution_clock::time_point t1);
 
     void showDuration(high_resolution_clock::time_point t1);


### PR DESCRIPTION
void showLinks(int32_t, int32_t, int32_t, int32_t, int32_t**)
Declaration was missing from wot.h, but was defined in wot.cpp. This commit fixes this.

(sorry if this is a weird pull request; it is my first time sending one to a repo.)
