### PR TITLE
Code acceleration, warning suppression

### DIFF
--- a/wotcpp/include/node.h
+++ b/wotcpp/include/node.h
@@ -5,8 +5,6 @@
 #include <cstddef>
 #include <vector>
 
-#include <unordered_map> 
-
 namespace libwot {
 
   class WebOfTrust;
@@ -48,8 +46,6 @@ namespace libwot {
 
 	  /// \brief Index of the node in the WoT
 	  uint32_t mIndex ;
-
-	  std::unordered_map<uint32_t, Node*> mCert2 ;
   };
 }
 

--- a/wotcpp/include/node.h
+++ b/wotcpp/include/node.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <vector>
 
+#include <unordered_map> 
 
 namespace libwot {
 
@@ -15,6 +16,7 @@ namespace libwot {
     public :
 
       Node(WebOfTrust* wot);
+      Node(WebOfTrust* wot, uint32_t pIndex);
       ~Node();
 
       bool isEnabled() {return mEnabled;};
@@ -24,7 +26,7 @@ namespace libwot {
 
 
       Node* setEnabled(bool enable);
-      std::vector<Node*> getLinks() {return mCert;};
+	  const std::vector<Node*> & getLinks() const {return mCert;};
 
       bool addLinkTo(uint32_t to);
       bool addLinkTo(Node* to);
@@ -34,12 +36,20 @@ namespace libwot {
       bool hasLinkFrom(Node* from);
       void removeLinkTo(uint32_t to);
 
+	  uint32_t get_index() const { return mIndex ; }
+	  void set_index(uint32_t pIndex) ;
+
     private :
 
       WebOfTrust *mWot;
       bool mEnabled;
       std::vector<Node*> mCert;
       uint32_t mNbIssued;
+
+	  /// \brief Index of the node in the WoT
+	  uint32_t mIndex ;
+
+	  std::unordered_map<uint32_t, Node*> mCert2 ;
   };
 }
 

--- a/wotcpp/include/webOfTrust.h
+++ b/wotcpp/include/webOfTrust.h
@@ -23,13 +23,13 @@ namespace libwot {
 
       void setMaxCert(uint32_t maxCert) { mMaxCert = maxCert; };
       uint32_t getMaxCert() {return mMaxCert;};
-      uint32_t getNodeIndex(Node* node);
+      uint32_t getNodeIndex(Node* node) const ;
       uint32_t getSize() { return mNodes.size();};
       uint32_t getEnabledCount() {
         int count = 0;
-        for (int n = 0; n < mNodes.size(); n++) {
+        for (size_t n = 0; n < mNodes.size(); ++n) {
           if (mNodes[n]->isEnabled()) {
-            count++;
+            ++count;
           }
         }
         return count;
@@ -62,11 +62,11 @@ namespace libwot {
       std::vector<uint32_t> getSentries(int d_min);
       std::vector<uint32_t> getNonSentries(int d_min);
       std::vector<uint32_t> getDisabled();
-      std::vector<std::vector<uint32_t>> getPaths(uint32_t from, uint32_t to, uint32_t k_max);
+      std::vector<std::vector<uint32_t>> getPaths(uint32_t from, uint32_t to, uint32_t k_max) const ;
 
     private :
 
-      void lookup(uint32_t from, uint32_t to, uint32_t distance, uint32_t distanceMax, WotStep* previous, std::vector<WotStep*>*, std::vector<WotStep*>* matchingPaths, uint32_t* wotChecked);
+      void lookup(uint32_t from, uint32_t to, uint32_t distance, uint32_t distanceMax, WotStep* previous, std::vector<WotStep*>*, std::vector<WotStep*>* matchingPaths, uint32_t* wotChecked) const ;
       std::vector<Node*> mNodes;	
       uint32_t mMaxCert;
   };

--- a/wotcpp/include/webOfTrust.h
+++ b/wotcpp/include/webOfTrust.h
@@ -35,6 +35,11 @@ namespace libwot {
         return count;
       };
       Node* getNodeAt(uint32_t index) { return mNodes.at(index);};
+
+	  /**
+		\brief Provide a node randomly
+		\note slow method if repeatedly called
+	  */
       Node* getRandomNode();
 
       Node* addNode();

--- a/wotcpp/node.cpp
+++ b/wotcpp/node.cpp
@@ -16,8 +16,17 @@ namespace libwot {
     mNbIssued = 0;
     mCert = vector<Node*>();
 	mCert.reserve(wot->getMaxCert()) ;
+	mIndex = UINT32_MAX ;
   }
 
+  Node::Node(WebOfTrust* wot, uint32_t pIndex) {
+    mWot = wot;
+    mEnabled = true;
+    mNbIssued = 0;
+    mCert = vector<Node*>();
+	mCert.reserve(wot->getMaxCert()) ;
+	mIndex = pIndex ;
+  }
 
   Node::~Node() {
   }
@@ -83,4 +92,9 @@ namespace libwot {
     }
   }
 
+	void Node::set_index(uint32_t pIndex)
+	{
+		mIndex = pIndex ;
+	}
 }
+

--- a/wotcpp/node.cpp
+++ b/wotcpp/node.cpp
@@ -15,6 +15,7 @@ namespace libwot {
     mEnabled = true;
     mNbIssued = 0;
     mCert = vector<Node*>();
+	mCert.reserve(wot->getMaxCert()) ;
   }
 
 

--- a/wotcpp/webOfTrust.cpp
+++ b/wotcpp/webOfTrust.cpp
@@ -313,7 +313,7 @@ namespace libwot {
 
   vector<uint32_t> WebOfTrust::getSentries(int d_min) {
     vector<uint32_t> set;
-	set.reserve(mModes.size()) ;
+	set.reserve(mNodes.size()) ;
     for (uint32_t i = 0; i < mNodes.size(); i++) {
       Node *node = mNodes.at(i);
       if (node->isEnabled() && d_min >= 0 && node->getNbIssued() >= (uint32_t)d_min && node->getNbLinks() >= (uint32_t)d_min) {
@@ -325,7 +325,7 @@ namespace libwot {
 
   vector<uint32_t> WebOfTrust::getNonSentries(int d_min) {
     vector<uint32_t> set;
-	set.reserve(mModes.size()) ;
+	set.reserve(mNodes.size()) ;
     for (uint32_t i = 0; i < mNodes.size(); i++) {
       Node *node = mNodes.at(i);
       if (node->isEnabled() && d_min >= 0 && (node->getNbIssued() < (uint32_t)d_min || node->getNbLinks() < (uint32_t)d_min)) {

--- a/wotcpp/webOfTrust.cpp
+++ b/wotcpp/webOfTrust.cpp
@@ -37,19 +37,26 @@ namespace libwot {
 
   WebOfTrust* WebOfTrust::createRandom(uint32_t nbMembers, uint32_t maxCertStock) {
     WebOfTrust *wot = new WebOfTrust(maxCertStock);
+	wot->mNodes.reserve(nbMembers) ;
     for (uint32_t i = 0; i < nbMembers; i++) {
       wot->addNode();
     }
+
+	// Random number generator
+	std::random_device rd;
+    std::mt19937 eng(rd());
+    std::uniform_int_distribution<> distr(0, nbMembers > 0 ? nbMembers - 1 : 0);
 
     for(vector<Node*>::iterator it = wot->mNodes.begin(); it != wot->mNodes.end(); it++) {
       Node* certified = NULL;
       for (uint32_t i = 0; i < maxCertStock; i++) {
         do{
-          certified = wot->getRandomNode();
+          certified = wot->mNodes.at(distr(eng)) ;
         } while (((Node*)*it)->addLinkTo(certified) != true);	
       }
       ((Node*)*it)->setEnabled(true);
     }
+
     return wot;
   }
 

--- a/wotcpp/webOfTrust.cpp
+++ b/wotcpp/webOfTrust.cpp
@@ -313,6 +313,7 @@ namespace libwot {
 
   vector<uint32_t> WebOfTrust::getSentries(int d_min) {
     vector<uint32_t> set;
+	set.reserve(mModes.size()) ;
     for (uint32_t i = 0; i < mNodes.size(); i++) {
       Node *node = mNodes.at(i);
       if (node->isEnabled() && d_min >= 0 && node->getNbIssued() >= (uint32_t)d_min && node->getNbLinks() >= (uint32_t)d_min) {
@@ -324,6 +325,7 @@ namespace libwot {
 
   vector<uint32_t> WebOfTrust::getNonSentries(int d_min) {
     vector<uint32_t> set;
+	set.reserve(mModes.size()) ;
     for (uint32_t i = 0; i < mNodes.size(); i++) {
       Node *node = mNodes.at(i);
       if (node->isEnabled() && d_min >= 0 && (node->getNbIssued() < (uint32_t)d_min || node->getNbLinks() < (uint32_t)d_min)) {

--- a/wotcpp/webOfTrust.cpp
+++ b/wotcpp/webOfTrust.cpp
@@ -367,17 +367,15 @@ namespace libwot {
 	result.reserve(matchingPaths.size()) ;
 
 	// Formatting as vectors
-	size_t j = 0 ;
     for (size_t i = 0; i < matchingPaths.size(); ++i) 
 	{
-      std::vector<uint32_t> thePath(k_max+1) ;
+      std::vector<uint32_t> thePath ;
+	  thePath.reserve(k_max+1) ;
       WotStep* step = matchingPaths[i];
-	  j = 0 ;
       while (step != NULL) 
 	  {
-		thePath[j] = step->member ;
+		thePath.push_back(step->member) ;
         step = step->previous;
-		++j ;
       }
       result.push_back(thePath);
     }


### PR DESCRIPTION
I conducted the following tests : 

1. create a random WoT with 100 000 members, each one having a 100 certifications stock ;
2. compute the paths between the two first nodes.

My laptop embeds a Intel Core i5-4210U CPU and 8Gb of memory.

The computing time are the following : 

1. The creation of a random WoT used to take 40 sec before, 2-3 sec now ;
2. The computation of the paths took 15 sec before, < 1 sec now.

With a small WoT, it was fine but it may not be the case with a larger one.

Numerous calls to getRandomNode() were slow. Also, the lookup of the node index was computationnaly costly. Therefore, I added the position of the node in the WoT (mIndex field).

I noticed other ways of improvement (e.g. : the hasLinkFrom() should provide an answer in constant time).

Anyway, I hope this will help. I also hope to not introduce bugs. Do not hesitate to criticize my modifications.